### PR TITLE
Rework functions options

### DIFF
--- a/functions/local-dependencies.bicep
+++ b/functions/local-dependencies.bicep
@@ -77,6 +77,8 @@ var regionName = loadJsonContent('../modules/global/regions.json')[location]
 @description('Global & naming conventions')
 var conventions = json(replace(replace(replace(replace(loadTextContent('../modules/global/conventions.json'), '%ORGANIZATION%', organizationName), '%APPLICATION%', applicationName), '%HOST%', hostName), '%REGION%', regionName))
 
+var storageAccounts = storageAccountsOptions.enabled ? storageAccountsOptions.accounts : []
+
 // === RESOURCES ===
 
 @description('Resource groupe tags')
@@ -103,7 +105,7 @@ module extra_sbn '../modules/communication/service-bus.bicep' = if (serviceBusOp
 }
 
 @description('Storage Accounts')
-module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccounts: if (storageAccountsOptions.enabled) {
   name: !contains(storageAccountOptions, 'suffix') ? 'empty' : 'Resource-StorageAccount-${storageAccountOptions.suffix}'
   params: {
     referential: tags.outputs.referential

--- a/functions/local-dependencies.bicep
+++ b/functions/local-dependencies.bicep
@@ -24,20 +24,44 @@ param hostName string
 param templateVersion string
 
 
-@description('The service bus options')
+@description('''
+The service bus options:
+- **enabled**: bool
+- **queues**: string[]
+''')
 param serviceBusOptions object = {
-  queues: []
-  authorizeClients: true
+  enabled: false
 }
 
-@description('The storage account options')
+@description('''
+The storage accounts options:
+- **enabled**: bool
+- **accounts**: array
+  - *suffix*: string
+  - **comment**: string
+  - **containers**: string[]
+  - *daysBeforeDeletion*: int
+  - *allowBlobPublicAccess*: bool
+''')
 param storageAccountsOptions object = {
-  accounts: []
-  authorizeClients: true
+  enabled: false
 }
 
-@description('The Cosmos DB containers')
-param cosmosContainers array = []
+@description('''
+The Cosmos account options:
+- **enabled**: bool
+- **containers**: array
+  - **name**
+  - **partitionKey**
+  - *uniqueKeys*
+  - *compositeIndexes*
+  - *includedPaths*
+  - *excludedPaths*
+  - *defaultTtl*
+''')
+param cosmosAccountOptions object = {
+  enabled: false
+}
 
 @description('The contribution groups')
 param contributionGroups array = []
@@ -52,9 +76,6 @@ var regionName = loadJsonContent('../modules/global/regions.json')[location]
 
 @description('Global & naming conventions')
 var conventions = json(replace(replace(replace(replace(loadTextContent('../modules/global/conventions.json'), '%ORGANIZATION%', organizationName), '%APPLICATION%', applicationName), '%HOST%', hostName), '%REGION%', regionName))
-
-var serviceBusQueues = !contains(serviceBusOptions, 'queues') ? [] : serviceBusOptions.queues
-var storageAccounts = !contains(storageAccountsOptions, 'accounts') ? [] : storageAccountsOptions.accounts
 
 // === RESOURCES ===
 
@@ -71,39 +92,35 @@ module tags '../modules/global/tags.bicep' = {
 }
 
 @description('Service Bus')
-module extra_sbn '../modules/communication/service-bus.bicep' = if (!empty(serviceBusQueues)) {
+module extra_sbn '../modules/communication/service-bus.bicep' = if (serviceBusOptions.enabled) {
   name: 'Resource-ServiceBus'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    serviceBusQueues: serviceBusQueues
+    serviceBusOptions: serviceBusOptions
   }
 }
 
 @description('Storage Accounts')
-module extra_stg '../modules/storage/storage-account.bicep' = [for account in storageAccounts: if (!empty(storageAccounts)) {
-  name: empty(account.suffix) ? 'empty' : 'Resource-StorageAccount-${account.suffix}'
+module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+  name: !contains(storageAccountOptions, 'suffix') ? 'empty' : 'Resource-StorageAccount-${storageAccountOptions.suffix}'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    comment: account.comment
-    suffix: account.suffix
-    blobContainers: account.containers
-    daysBeforeDeletion: account.daysBeforeDeletion
-    allowBlobPublicAccess: account.allowBlobPublicAccess
+    storageAccountOptions: storageAccountOptions
   }
 }]
 
-@description('Cosmos Accounts')
-module extra_cosmos '../modules/storage/cosmos-account.bicep' = if (!empty(cosmosContainers)) {
+@description('Cosmos Account')
+module extra_cosmos '../modules/storage/cosmos-account.bicep' = if (cosmosAccountOptions.enabled) {
   name: 'Resource-CosmosAccount'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    cosmosContainers: cosmosContainers
+    cosmosAccountOptions: cosmosAccountOptions
   }
 }
 

--- a/functions/local-dependencies.params.json
+++ b/functions/local-dependencies.params.json
@@ -13,15 +13,16 @@
     },
     "serviceBusOptions": {
       "value": {
+        "enabled": true,
         "queues": [
           "queue1",
           "queue2"
-        ],
-        "authorizeClients": true
+        ]
       }
     },
     "storageAccountsOptions": {
       "value": {
+        "enabled": true,
         "accounts": [
           {
             "suffix": "1",
@@ -30,43 +31,44 @@
               "container1",
               "container2"
             ],
-            "readOnly": true,
             "daysBeforeDeletion": 365,
             "allowBlobPublicAccess": false
           }
-        ],
-        "authorizeClients": true
+        ]
       }
     },
-    "cosmosContainers": {
-      "value": [
-        {
-          "name": "containerName",
-          "partitionKey": "/partitionKey",
-          "uniqueKeys": [
-            "/uniqueKey"
-          ],
-          "compositeIndexes": [
-            [
-              {  
-                "path": "/name",
-                "order": "ascending"
-              },
-              {  
-                "path": "/creation",
-                "order": "descending"
-              }
-            ]
-          ],
-          "includedPaths": [{
-            "path": "/*"
-          }],
-          "excludedPaths": [{
-            "path": "/\"_etag\"/?"
-          }],
-          "defaultTtl": 3600
-        }
-      ]
+    "cosmosAccountOptions": {
+      "value": {
+        "enabled": true,
+        "containers": [
+          {
+            "name": "containerName",
+            "partitionKey": "/partitionKey",
+            "uniqueKeys": [
+              "/uniqueKey"
+            ],
+            "compositeIndexes": [
+              [
+                {  
+                  "path": "/name",
+                  "order": "ascending"
+                },
+                {  
+                  "path": "/creation",
+                  "order": "descending"
+                }
+              ]
+            ],
+            "includedPaths": [{
+              "path": "/*"
+            }],
+            "excludedPaths": [{
+              "path": "/\"_etag\"/?"
+            }],
+            "defaultTtl": 3600
+          }
+        ]
+      }
     },
     "contributionGroups": {
       "value": [

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -24,12 +24,6 @@ param hostName string
 param templateVersion string
 
 
-@description('The application type')
-@allowed([
-  'isolatedDotnet6'
-])
-param applicationType string
-
 @description('The pricing plan')
 @allowed([
   'Free'    // The cheapest plan, can create some small fees
@@ -92,23 +86,25 @@ param staticWebAppOptions object = {
   enabled: false
 }
 
-@description('The application packages URI')
-param applicationPackageUri string = ''
-
-@description('The extra app settings to add')
-param extraAppSettings object = {}
-
-@description('The extra user-assigned identities to be used by the application')
-param extraIdentities object = {}
-
-@description('The extra deployment slots')
-param deploymentSlots array = []
+@description('''
+The Functions app options:
+- **stack**: string
+- *packageUri*: string
+- *extraAppSettings*: dictionary
+- *extraIdentities*: dictionary
+- *extraSlots*: array
+  - **name**
+- *openId*:
+  - **clientSecretKey**
+  - **endpoint**
+  - **apiClientId**
+  - *skipAuthentication*
+  - *anonymousEndpoints*
+''')
+param functionsAppOptions object
 
 @description('The contribution groups')
 param contributionGroups array = []
-
-@description('The OpenID configuration for authentication')
-param openIdConfiguration object = {}
 
 @description('The deployment location')
 param location string = resourceGroup().location
@@ -254,17 +250,12 @@ module fn '../modules/applications/functions/application.bicep' = {
     pricingPlan: pricingPlan
     userAssignedIdentityId: userAssignedIdentity_application.outputs.id
     userAssignedIdentityClientId: userAssignedIdentity_application.outputs.clientId
-    applicationType: applicationType
     serverFarmId: asp.outputs.id
     webJobsStorageAccountName: stg.outputs.name
     aiConnectionString: ai.outputs.connectionString
     serviceBusNamespaceName: serviceBusOptions.enabled ? extra_sbn.outputs.name : ''
     kvVaultUri: kv.outputs.vaultUri
-    applicationPackageUri: applicationPackageUri
-    extraAppSettings: extraAppSettings
-    extraIdentities: extraIdentities
-    deploymentSlots: deploymentSlots
-    openIdConfiguration: openIdConfiguration
+    functionsAppOptions: functionsAppOptions
   }
 }
 

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -37,14 +37,46 @@ param applicationType string
 ])
 param pricingPlan string = 'Free'
 
-@description('The service bus options')
+@description('''
+The service bus options:
+- **enabled**: bool
+- *queues*: string[]
+- *authorizeClients*: bool
+''')
 param serviceBusOptions object = {
-  queues: []
+  enabled: false
 }
 
-@description('The storage account options')
+@description('''
+The storage accounts options:
+- **enabled**: bool
+- **accounts**: array
+  - **suffix**: string
+  - **comment**: string
+  - **containers**: string[]
+  - *daysBeforeDeletion*: int
+  - *allowBlobPublicAccess*: bool
+  - *authorizeClients*: bool
+  - *readOnly*
+''')
 param storageAccountsOptions object = {
-  accounts: []
+  enabled: false
+}
+
+@description('''
+The Cosmos account options:
+- **enabled**: bool
+- **containers**: array
+  - **name**
+  - **partitionKey**
+  - *uniqueKeys*
+  - *compositeIndexes*
+  - *includedPaths*
+  - *excludedPaths*
+  - *defaultTtl*
+''')
+param cosmosAccountOptions object = {
+  enabled: false
 }
 
 @description('The application packages URI')
@@ -55,9 +87,6 @@ param extraAppSettings object = {}
 
 @description('The extra user-assigned identities to be used by the application')
 param extraIdentities object = {}
-
-@description('The Cosmos DB containers')
-param cosmosContainers array = []
 
 @description('The extra deployment slots')
 param deploymentSlots array = []
@@ -89,9 +118,6 @@ var webTestsSettings = loadJsonContent('../modules/global/organization-based/web
 
 @description('Extended monitoring')
 var extendedMonitoring = startsWith(hostName, 'prd')
-
-var serviceBusQueues = !contains(serviceBusOptions, 'queues') ? [] : serviceBusOptions.queues
-var storageAccounts = !contains(storageAccountsOptions, 'accounts') ? [] : storageAccountsOptions.accounts
 
 // === RESOURCES ===
 
@@ -152,39 +178,35 @@ module ai '../modules/monitoring/app-insights.bicep' = {
 }
 
 @description('Service Bus')
-module extra_sbn '../modules/communication/service-bus.bicep' = if (!empty(serviceBusQueues)) {
+module extra_sbn '../modules/communication/service-bus.bicep' = if (serviceBusOptions.enabled) {
   name: 'Resource-ServiceBus'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    serviceBusQueues: serviceBusQueues
+    serviceBusOptions: serviceBusOptions
   }
 }
 
 @description('Storage Accounts')
-module extra_stg '../modules/storage/storage-account.bicep' = [for account in storageAccounts: if (!empty(storageAccounts)) {
-  name: empty(account.suffix) ? 'empty' : 'Resource-StorageAccount-${account.suffix}'
+module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+  name: empty(storageAccountOptions) ? 'empty' : 'Resource-StorageAccount-${storageAccountOptions.suffix}'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    comment: account.comment
-    suffix: account.suffix
-    blobContainers: account.containers
-    daysBeforeDeletion: account.daysBeforeDeletion
-    allowBlobPublicAccess: account.allowBlobPublicAccess
+    storageAccountOptions: storageAccountOptions
   }
 }]
 
-@description('Cosmos Accounts')
-module extra_cosmos '../modules/storage/cosmos-account.bicep' = if (!empty(cosmosContainers)) {
+@description('Cosmos Account')
+module extra_cosmos '../modules/storage/cosmos-account.bicep' = if (cosmosAccountOptions.enabled) {
   name: 'Resource-CosmosAccount'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    cosmosContainers: cosmosContainers
+    cosmosAccountOptions: cosmosAccountOptions
   }
 }
 
@@ -195,10 +217,12 @@ module stg '../modules/storage/storage-account.bicep' = {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
-    comment: 'Technical storage for Functions application'
-    blobContainers: [
-      'deployment-packages'
-    ]
+    storageAccountOptions: {
+      comment: 'Technical storage for Functions application'
+      containers: [
+        'deployment-packages'
+      ]
+    }
   }
 }
 
@@ -226,7 +250,7 @@ module fn '../modules/applications/functions/application.bicep' = {
     serverFarmId: asp.outputs.id
     webJobsStorageAccountName: stg.outputs.name
     aiConnectionString: ai.outputs.connectionString
-    serviceBusNamespaceName: !empty(serviceBusQueues) ? extra_sbn.outputs.name : ''
+    serviceBusNamespaceName: serviceBusOptions.enabled ? extra_sbn.outputs.name : ''
     kvVaultUri: kv.outputs.vaultUri
     applicationPackageUri: applicationPackageUri
     extraAppSettings: extraAppSettings
@@ -300,44 +324,44 @@ module auth_fn_ai '../modules/authorizations/subscription/monitoring-data.bicep'
 }
 
 @description('Functions to extra Service Bus')
-module auth_fn_extra_sbn '../modules/authorizations/subscription/service-bus-data.bicep' = if (!empty(serviceBusQueues)) {
+module auth_fn_extra_sbn '../modules/authorizations/subscription/service-bus-data.bicep' = if (serviceBusOptions.enabled) {
   name: 'Authorization-Functions-ServiceBus'
   params: {
     principalId: userAssignedIdentity_application.outputs.principalId
-    serviceBusNamespaceName: !empty(serviceBusQueues) ? extra_sbn.outputs.name : ''
+    serviceBusNamespaceName: serviceBusOptions.enabled ? extra_sbn.outputs.name : ''
     roleType: 'Owner'
     roleDescription: 'Functions application should read, write and manage the messages from Service Bus'
   }
 }
 
 @description('Functions to extra Storage Accounts')
-module auth_fn_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (account, index) in storageAccounts: if (!empty(storageAccounts)) {
-  name: empty(account) ? 'empty' : 'Authorization-Functions-StorageAccount${account.suffix}'
+module auth_fn_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+  name: empty(storageAccountOptions) ? 'empty' : 'Authorization-Functions-StorageAccount${storageAccountOptions.suffix}'
   params: {
     principalId: userAssignedIdentity_application.outputs.principalId
     storageAccountName: extra_stg[index].outputs.name
-    roleType: account.readOnly ? 'Reader' : 'Contributor'
+    roleType: contains(storageAccountOptions, 'readOnly') && storageAccountOptions.readOnly ? 'Reader' : 'Contributor'
     roleDescription: 'Functions application should read/write the blobs from Storage Account'
   }
 }]
 
 @description('Functions to extra Cosmos DB Account')
-module auth_fn_extra_cosmos '../modules/authorizations/subscription/cosmos-db-data.bicep' = if (!empty(cosmosContainers)) {
+module auth_fn_extra_cosmos '../modules/authorizations/subscription/cosmos-db-data.bicep' = if (cosmosAccountOptions.enabled) {
   name: 'Authorization-Functions-CosmosAccount'
   params: {
     principalId: userAssignedIdentity_application.outputs.principalId
-    cosmosAccountName: !empty(cosmosContainers) ? extra_cosmos.outputs.name : ''
+    cosmosAccountName: cosmosAccountOptions.enabled ? extra_cosmos.outputs.name : ''
     roleType: 'Contributor'
   }
 }
 
 @description('Contribution authorization to extra Cosmos DB Accounts')
 @batchSize(1) // This is needed because Azure Cosmos DB assignements can't be performed in parallel
-module auth_contributors_cosmos '../modules/authorizations/subscription/cosmos-db-data.bicep' = [for (group, index) in contributionGroups: if (!empty(cosmosContainers) && !empty(contributionGroups)) {
+module auth_contributors_cosmos '../modules/authorizations/subscription/cosmos-db-data.bicep' = [for (group, index) in contributionGroups: if (cosmosAccountOptions.enabled && !empty(contributionGroups)) {
   name: empty(group) ? 'empty' : 'Authorization-ContributionGroup-${index}-CosmosAccount'
   params: {
     principalId: group.id
-    cosmosAccountName: !empty(cosmosContainers) ? extra_cosmos.outputs.name : ''
+    cosmosAccountName: cosmosAccountOptions.enabled ? extra_cosmos.outputs.name : ''
     roleType: 'Contributor'
   }
   dependsOn: [
@@ -357,19 +381,19 @@ module auth_fn_stg  '../modules/authorizations/subscription/storage-blob-data.bi
 }
 
 @description('Clients UAI to extra Service Bus')
-module auth_clients_extra_sbn '../modules/authorizations/subscription/service-bus-data.bicep' = if (!empty(serviceBusQueues) && contains(serviceBusOptions, 'authorizeClients') && serviceBusOptions.authorizeClients) {
+module auth_clients_extra_sbn '../modules/authorizations/subscription/service-bus-data.bicep' = if (serviceBusOptions.enabled && contains(serviceBusOptions, 'authorizeClients') && serviceBusOptions.authorizeClients) {
   name: 'Authorization-Clients-ServiceBus'
   params: {
     principalId: userAssignedIdentity_clients.outputs.principalId
-    serviceBusNamespaceName: !empty(serviceBusQueues) ? extra_sbn.outputs.name : ''
+    serviceBusNamespaceName: serviceBusOptions.enabled ? extra_sbn.outputs.name : ''
     roleType: 'Sender'
     roleDescription: 'Functions application clients should write messages to Service Bus'
   }
 }
 
 @description('Clients UAI to extra Storage Accounts')
-module auth_clients_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (account, index) in storageAccounts: if (!empty(storageAccounts) && contains(account, 'authorizeClients') && account.authorizeClients) {
-  name: empty(account) ? 'empty' : 'Authorization-Clients-StorageAccount${account.suffix}'
+module auth_clients_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled && contains(storageAccountOptions, 'authorizeClients') && storageAccountOptions.authorizeClients) {
+  name: empty(storageAccountOptions) ? 'empty' : 'Authorization-Clients-StorageAccount${storageAccountOptions.suffix}'
   params: {
     principalId: userAssignedIdentity_clients.outputs.principalId
     storageAccountName: extra_stg[index].outputs.name

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -123,6 +123,8 @@ var webTestsSettings = loadJsonContent('../modules/global/organization-based/web
 @description('Extended monitoring')
 var extendedMonitoring = startsWith(hostName, 'prd')
 
+var storageAccounts = storageAccountsOptions.enabled ? storageAccountsOptions.accounts : []
+
 // === RESOURCES ===
 
 @description('Resource groupe tags')
@@ -193,7 +195,7 @@ module extra_sbn '../modules/communication/service-bus.bicep' = if (serviceBusOp
 }
 
 @description('Storage Accounts')
-module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+module extra_stg '../modules/storage/storage-account.bicep' = [for storageAccountOptions in storageAccounts: if (storageAccountsOptions.enabled) {
   name: empty(storageAccountOptions) ? 'empty' : 'Resource-StorageAccount-${storageAccountOptions.suffix}'
   params: {
     referential: tags.outputs.referential
@@ -334,7 +336,7 @@ module auth_fn_extra_sbn '../modules/authorizations/subscription/service-bus-dat
 }
 
 @description('Functions to extra Storage Accounts')
-module auth_fn_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled) {
+module auth_fn_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccounts: if (storageAccountsOptions.enabled) {
   name: empty(storageAccountOptions) ? 'empty' : 'Authorization-Functions-StorageAccount${storageAccountOptions.suffix}'
   params: {
     principalId: userAssignedIdentity_application.outputs.principalId
@@ -391,7 +393,7 @@ module auth_clients_extra_sbn '../modules/authorizations/subscription/service-bu
 }
 
 @description('Clients UAI to extra Storage Accounts')
-module auth_clients_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccountsOptions.accounts: if (storageAccountsOptions.enabled && contains(storageAccountOptions, 'authorizeClients') && storageAccountOptions.authorizeClients) {
+module auth_clients_extra_stg '../modules/authorizations/subscription/storage-blob-data.bicep' = [for (storageAccountOptions, index) in storageAccounts: if (storageAccountsOptions.enabled && contains(storageAccountOptions, 'authorizeClients') && storageAccountOptions.authorizeClients) {
   name: empty(storageAccountOptions) ? 'empty' : 'Authorization-Clients-StorageAccount${storageAccountOptions.suffix}'
   params: {
     principalId: userAssignedIdentity_clients.outputs.principalId

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -102,6 +102,9 @@ The Functions app options:
 ''')
 param functionsAppOptions object
 
+@description('The application package URI')
+param applicationPackageUri string = ''
+
 @description('The contribution groups')
 param contributionGroups array = []
 
@@ -257,6 +260,7 @@ module fn '../modules/applications/functions/application.bicep' = {
     serviceBusNamespaceName: serviceBusOptions.enabled ? extra_sbn.outputs.name : ''
     kvVaultUri: kv.outputs.vaultUri
     functionsAppOptions: functionsAppOptions
+    applicationPackageUri: applicationPackageUri
   }
 }
 

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -89,7 +89,6 @@ param staticWebAppOptions object = {
 @description('''
 The Functions app options:
 - **stack**: string
-- *packageUri*: string
 - *extraAppSettings*: dictionary
 - *extraIdentities*: dictionary
 - *extraSlots*: array

--- a/functions/template.bicep
+++ b/functions/template.bicep
@@ -57,7 +57,7 @@ The storage accounts options:
   - *daysBeforeDeletion*: int
   - *allowBlobPublicAccess*: bool
   - *authorizeClients*: bool
-  - *readOnly*
+  - *readOnly*: bool
 ''')
 param storageAccountsOptions object = {
   enabled: false
@@ -67,15 +67,28 @@ param storageAccountsOptions object = {
 The Cosmos account options:
 - **enabled**: bool
 - **containers**: array
-  - **name**
-  - **partitionKey**
-  - *uniqueKeys*
-  - *compositeIndexes*
-  - *includedPaths*
-  - *excludedPaths*
-  - *defaultTtl*
+  - **name**: string
+  - **partitionKey**: string
+  - *uniqueKeys*: string[]
+  - *compositeIndexes*: array of array
+    - **path**: string
+    - **order**: string
+  - *includedPaths*: array
+    - **path**: string
+  - *excludedPaths*: array
+    - **path**: string
+  - *defaultTtl*: int
 ''')
 param cosmosAccountOptions object = {
+  enabled: false
+}
+
+@description('''
+The Static Web app options:
+- **enabled**: bool
+- *customDomains*: string[]
+''')
+param staticWebAppOptions object = {
   enabled: false
 }
 
@@ -93,11 +106,6 @@ param deploymentSlots array = []
 
 @description('The contribution groups')
 param contributionGroups array = []
-
-@description('The static web app to attach')
-param staticWebApp object = {
-  enabled: false
-}
 
 @description('The OpenID configuration for authentication')
 param openIdConfiguration object = {}
@@ -261,14 +269,14 @@ module fn '../modules/applications/functions/application.bicep' = {
 }
 
 @description('Static Web Apps application')
-module swa '../modules/applications/static/application.bicep' = if (staticWebApp.enabled) {
+module swa '../modules/applications/static/application.bicep' = if (staticWebAppOptions.enabled) {
   name: 'Resource-StaticWebAppsApplication'
   params: {
     referential: tags.outputs.referential
     conventions: conventions
     location: location
     pricingPlan: pricingPlan
-    customDomains: !contains(staticWebApp, 'customDomains') ? [] : staticWebApp.customDomains
+    staticWebAppOptions: staticWebAppOptions
   }
 }
 

--- a/functions/template.params.json
+++ b/functions/template.params.json
@@ -19,6 +19,7 @@
     },
     "serviceBusOptions": {
       "value": {
+        "enabled": true,
         "queues": [
           "queue1",
           "queue2"
@@ -28,6 +29,7 @@
     },
     "storageAccountsOptions": {
       "value": {
+        "enabled": true,
         "accounts": [
           {
             "suffix": "1",
@@ -44,6 +46,39 @@
         ]
       }
     },
+    "cosmosAccountOptions": {
+      "value": {
+        "enabled": true,
+        "containers": [
+          {
+            "name": "containerName",
+            "partitionKey": "/partitionKey",
+            "uniqueKeys": [
+              "/uniqueKey"
+            ],
+            "compositeIndexes": [
+              [
+                {  
+                  "path": "/name",
+                  "order": "ascending"
+                },
+                {  
+                  "path": "/creation",
+                  "order": "descending"
+                }
+              ]
+            ],
+            "includedPaths": [{
+              "path": "/*"
+            }],
+            "excludedPaths": [{
+              "path": "/\"_etag\"/?"
+            }],
+            "defaultTtl": 3600
+          }
+        ]
+      }
+    },
     "extraAppSettings": {
       "value": {
         "key1": "value1",
@@ -54,36 +89,6 @@
       "value": {
         "/subscriptions/xxx/resourcegroups/xxx/Microsoft.ManagedIdentity/userAssignedIdentities/xxx": {}
       }
-    },
-    "cosmosContainers": {
-      "value": [
-        {
-          "name": "containerName",
-          "partitionKey": "/partitionKey",
-          "uniqueKeys": [
-            "/uniqueKey"
-          ],
-          "compositeIndexes": [
-            [
-              {  
-                "path": "/name",
-                "order": "ascending"
-              },
-              {  
-                "path": "/creation",
-                "order": "descending"
-              }
-            ]
-          ],
-          "includedPaths": [{
-            "path": "/*"
-          }],
-          "excludedPaths": [{
-            "path": "/\"_etag\"/?"
-          }],
-          "defaultTtl": 3600
-        }
-      ]
     },
     "deploymentSlots": {
       "value": [

--- a/functions/template.params.json
+++ b/functions/template.params.json
@@ -79,7 +79,7 @@
         ]
       }
     },
-    "staticWebApp": {
+    "staticWebAppOptions": {
       "value": {
         "enabled": true,
         "customDomains": [

--- a/functions/template.params.json
+++ b/functions/template.params.json
@@ -79,6 +79,14 @@
         ]
       }
     },
+    "staticWebApp": {
+      "value": {
+        "enabled": true,
+        "customDomains": [
+          "subdomain.domain.com"
+        ]
+      }
+    },
     "extraAppSettings": {
       "value": {
         "key1": "value1",
@@ -96,14 +104,6 @@
           "name": "dev-bis"
         }
       ]
-    },
-    "staticWebApp": {
-      "value": {
-        "enabled": true,
-        "customDomains": [
-          "subdomain.domain.com"
-        ]
-      }
     },
     "contributionGroups": {
       "value": [

--- a/functions/template.params.json
+++ b/functions/template.params.json
@@ -14,9 +14,6 @@
     "pricingPlan": {
       "value": "Free"
     },
-    "applicationType": {
-      "value": "isolatedDotnet6"
-    },
     "serviceBusOptions": {
       "value": {
         "enabled": true,
@@ -87,23 +84,31 @@
         ]
       }
     },
-    "extraAppSettings": {
+    "functionsAppOptions": {
       "value": {
-        "key1": "value1",
-        "key2": "<secret>secret_name</secret>"
-      }
-    },
-    "extraIdentities": {
-      "value": {
-        "/subscriptions/xxx/resourcegroups/xxx/Microsoft.ManagedIdentity/userAssignedIdentities/xxx": {}
-      }
-    },
-    "deploymentSlots": {
-      "value": [
-        {
-          "name": "dev-bis"
+        "stack": "isolatedDotnet6",
+        "extraAppSettings": {
+          "key1": "value1",
+          "key2": "<secret>secret_name</secret>"
+        },
+        "extraIdentities": {
+          "/subscriptions/xxx/resourcegroups/xxx/Microsoft.ManagedIdentity/userAssignedIdentities/xxx": {}
+        },
+        "extraSlots": [
+          {
+            "name": "dev-bis"
+          }
+        ],
+        "openId": {
+          "endpoint": "https://B2CTENANT.b2clogin.com/TENANT.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_FLOWNAME",
+          "apiClientId": "00000000-0000-0000-0000-000000000000",
+          "clientSecretKey": "<secret>Identity--Secret</secret>",
+          "skipAuthentication": false,
+          "anonymousEndpoints": [
+            "/api/anonymous-route"
+          ]
         }
-      ]
+      }
     },
     "contributionGroups": {
       "value": [
@@ -111,17 +116,6 @@
           "id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
         }
       ]
-    },
-    "openIdConfiguration": {
-      "value": {
-        "endpoint": "https://B2CTENANT.b2clogin.com/TENANT.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_FLOWNAME",
-        "apiClientId": "00000000-0000-0000-0000-000000000000",
-        "clientSecretKey": "<secret>Identity--Secret</secret>",
-        "skipAuthentication": false,
-        "anonymousEndpoints": [
-          "/api/anonymous-route"
-        ]
-      }
     }
   }
 }

--- a/modules/applications/functions/application.bicep
+++ b/modules/applications/functions/application.bicep
@@ -118,7 +118,7 @@ var appSettings = union(formattedExtraAppSettings, {
   AzureWebJobsServiceBus__clientId: userAssignedIdentityClientId
 }, empty(applicationPackageUri) ? {} : {
   // Application deployment package URI
-  WEBSITE_RUN_FROM_PACKAGE: functionsAppOptions.packageUri
+  WEBSITE_RUN_FROM_PACKAGE: applicationPackageUri
 }, !enableOpenId ? {} : {
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: formattedOpenIdSecret
 })

--- a/modules/applications/functions/application.bicep
+++ b/modules/applications/functions/application.bicep
@@ -114,9 +114,6 @@ var appSettings = union(formattedExtraAppSettings, {
   AzureWebJobsServiceBus__fullyQualifiedNamespace: '${serviceBusNamespaceName}.servicebus.windows.net'
   AzureWebJobsServiceBus__credential: 'managedidentity'
   AzureWebJobsServiceBus__clientId: userAssignedIdentityClientId
-}, contains(functionsAppOptions, 'packageUri') ? {} : {
-  // Application deployment package URI
-  WEBSITE_RUN_FROM_PACKAGE: functionsAppOptions.packageUri
 }, !enableOpenId ? {} : {
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: formattedOpenIdSecret
 })

--- a/modules/applications/functions/application.bicep
+++ b/modules/applications/functions/application.bicep
@@ -23,11 +23,9 @@ param userAssignedIdentityId string
 @description('The Client ID of the User-Assigned Identity to use')
 param userAssignedIdentityClientId string
 
-@description('The application type')
-@allowed([
-  'isolatedDotnet6'
-])
-param applicationType string
+
+@description('The Functions app options')
+param functionsAppOptions object
 
 @description('The server farm ID')
 param serverFarmId string
@@ -42,22 +40,7 @@ param kvVaultUri string
 param aiConnectionString string
 
 @description('The Service Bus Namespace name')
-param serviceBusNamespaceName string = ''
-
-@description('The application packages URI')
-param applicationPackageUri string = ''
-
-@description('The application secret names')
-param extraAppSettings object = {}
-
-@description('The extra user-assigned identities to be used by the application')
-param extraIdentities object = {}
-
-@description('The extra deployment slots')
-param deploymentSlots array = []
-
-@description('The OpenID configuration for authentication')
-param openIdConfiguration object = {}
+param serviceBusNamespaceName string
 
 @description('The deployment location')
 param location string
@@ -66,16 +49,15 @@ param location string
 
 // General settings
 var dailyMemoryTimeQuota = pricingPlan == 'Free' ? '10000' : pricingPlan == 'Basic' ? '1000000' : 'ERROR' // in GB.s/d
-var linuxFxVersion = applicationType == 'isolatedDotnet6' ? 'DOTNET-ISOLATED|6.0' : 'ERROR'
+var linuxFxVersion = functionsAppOptions.stack == 'isolatedDotnet6' ? 'DOTNET-ISOLATED|6.0' : 'ERROR'
 
 // OpenID
-var enableOpenId = contains(openIdConfiguration, 'clientSecretKey') && contains(openIdConfiguration, 'endpoint') && contains(openIdConfiguration, 'apiClientId')
-var formattedOpenIdSecret = enableOpenId ? replace(replace(openIdConfiguration.clientSecretKey, '<secret>', '@Microsoft.KeyVault(SecretUri=${kvVaultUri}secrets/'), '</secret>', ')') : ''
+var enableOpenId = contains(functionsAppOptions, 'openId')
+var formattedOpenIdSecret = enableOpenId ? replace(replace(functionsAppOptions.openId.clientSecretKey, '<secret>', '@Microsoft.KeyVault(SecretUri=${kvVaultUri}secrets/'), '</secret>', ')') : ''
 var defaultAnonymousEndpoints = loadJsonContent('../../global/anonymous-endpoints.json')
-var skipAuthentication = contains(openIdConfiguration, 'skipAuthentication') && openIdConfiguration.skipAuthentication
-var anonymousEndpoints = enableOpenId ? contains(openIdConfiguration, 'anonymousEndpoints') ? union(defaultAnonymousEndpoints, openIdConfiguration.anonymousEndpoints) : defaultAnonymousEndpoints : []
 
 // Identity settings
+var extraIdentities = contains(functionsAppOptions, 'extraIdentities') ? functionsAppOptions.extraIdentities : {}
 var identitySettings = {
   type: 'UserAssigned'
   userAssignedIdentities: union({
@@ -103,6 +85,7 @@ var webSettings = {
 }
 
 // App settings
+var extraAppSettings = contains(functionsAppOptions, 'extraAppSettings') ? functionsAppOptions.extraAppSettings : {}
 var formattedExtraAppSettings = json(replace(replace(string(extraAppSettings), '<secret>', '@Microsoft.KeyVault(SecretUri=${kvVaultUri}secrets/'), '</secret>', ')'))
 var appSettings = union(formattedExtraAppSettings, {
   // General hosting information
@@ -112,8 +95,8 @@ var appSettings = union(formattedExtraAppSettings, {
   AZURE_FUNCTIONS_HOST: referential.host
   AZURE_FUNCTIONS_REGION: referential.region
   // Functions runtime configuration
-  FUNCTIONS_EXTENSION_VERSION: applicationType == 'isolatedDotnet6' ? '~4' : 'ERROR'
-  FUNCTIONS_WORKER_RUNTIME: applicationType == 'isolatedDotnet6' ? 'dotnet-isolated' : 'ERROR'
+  FUNCTIONS_EXTENSION_VERSION: functionsAppOptions.stack == 'isolatedDotnet6' ? '~4' : 'ERROR'
+  FUNCTIONS_WORKER_RUNTIME: functionsAppOptions.stack == 'isolatedDotnet6' ? 'dotnet-isolated' : 'ERROR'
   // Functions misc configuration
   AzureWebJobsDisableHomepage: 'true'
   // Connection information for Storage Account (triggers management)
@@ -131,9 +114,9 @@ var appSettings = union(formattedExtraAppSettings, {
   AzureWebJobsServiceBus__fullyQualifiedNamespace: '${serviceBusNamespaceName}.servicebus.windows.net'
   AzureWebJobsServiceBus__credential: 'managedidentity'
   AzureWebJobsServiceBus__clientId: userAssignedIdentityClientId
-}, empty(applicationPackageUri) ? {} : {
+}, contains(functionsAppOptions, 'packageUri') ? {} : {
   // Application deployment package URI
-  WEBSITE_RUN_FROM_PACKAGE: applicationPackageUri
+  WEBSITE_RUN_FROM_PACKAGE: functionsAppOptions.packageUri
 }, !enableOpenId ? {} : {
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: formattedOpenIdSecret
 })
@@ -146,17 +129,17 @@ var slotSettings = {
 }
 
 // Auth settings
-var authSettings = {
+var authSettings = enableOpenId ? {
   platform: {
     enabled: true
   }
-  globalValidation: skipAuthentication ? {
+  globalValidation: contains(functionsAppOptions.openId, 'skipAuthentication') && functionsAppOptions.openId.skipAuthentication ? {
     requireAuthentication: false
     unauthenticatedClientAction: 'AllowAnonymous'
   } : {
     requireAuthentication: true
     unauthenticatedClientAction: 'Return401'
-    excludedPaths: anonymousEndpoints
+    excludedPaths: contains(functionsAppOptions.openId, 'anonymousEndpoints') ? union(defaultAnonymousEndpoints, functionsAppOptions.openId.anonymousEndpoints) : defaultAnonymousEndpoints
   }
   login: {
     tokenStore: {
@@ -170,13 +153,13 @@ var authSettings = {
     azureActiveDirectory: {
       enabled: true
       registration: {
-        clientId: openIdConfiguration.apiClientId
+        clientId: functionsAppOptions.openId.apiClientId
         clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
-        openIdIssuer: openIdConfiguration.endpoint
+        openIdIssuer: functionsAppOptions.openId.endpoint
       }
     }
   }
-}
+} : {}
 
 // === RESOURCES ===
 
@@ -214,7 +197,8 @@ resource fn 'Microsoft.Web/sites@2021-03-01' = {
   }
 }
 
-module slots './application-slot.bicep' = [for deploymentSlot in deploymentSlots: {
+@description('The extra deployment slots')
+module slots './application-slot.bicep' = [for deploymentSlot in functionsAppOptions.extraSlots: if (contains(functionsAppOptions, 'extraSlots')) {
   name: 'Resource-FunctionsSlot-${deploymentSlot.name}'
   params: {
     referential: referential

--- a/modules/applications/functions/application.bicep
+++ b/modules/applications/functions/application.bicep
@@ -23,7 +23,6 @@ param userAssignedIdentityId string
 @description('The Client ID of the User-Assigned Identity to use')
 param userAssignedIdentityClientId string
 
-
 @description('The Functions app options')
 param functionsAppOptions object
 
@@ -41,6 +40,9 @@ param aiConnectionString string
 
 @description('The Service Bus Namespace name')
 param serviceBusNamespaceName string
+
+@description('The application package URI')
+param applicationPackageUri string
 
 @description('The deployment location')
 param location string
@@ -114,6 +116,9 @@ var appSettings = union(formattedExtraAppSettings, {
   AzureWebJobsServiceBus__fullyQualifiedNamespace: '${serviceBusNamespaceName}.servicebus.windows.net'
   AzureWebJobsServiceBus__credential: 'managedidentity'
   AzureWebJobsServiceBus__clientId: userAssignedIdentityClientId
+}, empty(applicationPackageUri) ? {} : {
+  // Application deployment package URI
+  WEBSITE_RUN_FROM_PACKAGE: functionsAppOptions.packageUri
 }, !enableOpenId ? {} : {
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: formattedOpenIdSecret
 })

--- a/modules/applications/functions/application.bicep
+++ b/modules/applications/functions/application.bicep
@@ -52,6 +52,7 @@ param location string
 // General settings
 var dailyMemoryTimeQuota = pricingPlan == 'Free' ? '10000' : pricingPlan == 'Basic' ? '1000000' : 'ERROR' // in GB.s/d
 var linuxFxVersion = functionsAppOptions.stack == 'isolatedDotnet6' ? 'DOTNET-ISOLATED|6.0' : 'ERROR'
+var extraSlots = contains(functionsAppOptions, 'extraSlots') ? functionsAppOptions.extraSlots : []
 
 // OpenID
 var enableOpenId = contains(functionsAppOptions, 'openId')
@@ -200,7 +201,7 @@ resource fn 'Microsoft.Web/sites@2021-03-01' = {
 }
 
 @description('The extra deployment slots')
-module slots './application-slot.bicep' = [for deploymentSlot in functionsAppOptions.extraSlots: if (contains(functionsAppOptions, 'extraSlots')) {
+module slots './application-slot.bicep' = [for deploymentSlot in extraSlots: if (contains(functionsAppOptions, 'extraSlots')) {
   name: 'Resource-FunctionsSlot-${deploymentSlot.name}'
   params: {
     referential: referential

--- a/modules/applications/static/application.bicep
+++ b/modules/applications/static/application.bicep
@@ -17,8 +17,8 @@ param conventions object
 ])
 param pricingPlan string
 
-@description('The application custom domains')
-param customDomains array = []
+@description('The Static Web app options')
+param staticWebAppOptions object
 
 @description('The deployment location')
 param location string
@@ -49,7 +49,7 @@ resource swa 'Microsoft.Web/staticSites@2021-02-01' = {
 }
 
 @description('Custom domains for Static Web Apps')
-module domains 'custom-domain.bicep' = [for (customDomain, i) in customDomains: if (!empty(customDomains)) {
+module domains 'custom-domain.bicep' = [for (customDomain, i) in staticWebAppOptions.customDomains: if (contains(staticWebAppOptions, 'customDomains')) {
   name: 'Resource-CustomDomain-${customDomain}'
   params: {
     conventions: conventions

--- a/modules/communication/service-bus.bicep
+++ b/modules/communication/service-bus.bicep
@@ -10,8 +10,8 @@ param referential object
 @description('The naming convention, from the conventions.json file')
 param conventions object
 
-@description('The Service Bus queues')
-param serviceBusQueues array = []
+@description('The Service Bus options')
+param serviceBusOptions object
 
 @description('The deployment location')
 param location string
@@ -33,8 +33,8 @@ resource sbn 'Microsoft.ServiceBus/namespaces@2022-01-01-preview' = {
   }
 
   // Service Bus Queues
-  resource queues 'queues' = [for queue in serviceBusQueues: if (length(serviceBusQueues) > 0) {
-    name: empty(serviceBusQueues) ? 'empty' : queue
+  resource queues 'queues' = [for queue in serviceBusOptions.queues: if (length(serviceBusOptions.queues) > 0) {
+    name: empty(serviceBusOptions.queues) ? 'empty' : queue
     properties: {
       lockDuration: 'PT30S'
       maxSizeInMegabytes: 1024

--- a/modules/storage/cosmos-account.bicep
+++ b/modules/storage/cosmos-account.bicep
@@ -10,8 +10,8 @@ param referential object
 @description('The naming convention, from the conventions.json file')
 param conventions object
 
-@description('the Cosmos DB containers')
-param cosmosContainers array
+@description('The Cosmos account options')
+param cosmosAccountOptions object
 
 @description('The deployment location')
 param location string
@@ -72,7 +72,7 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2021-10-15' = {
     }
 
     // Cosmos DB Containers
-    resource containers 'containers' = [for (container, index) in cosmosContainers: {
+    resource containers 'containers' = [for (container, index) in cosmosAccountOptions.containers: {
       name: container.name
       location: location
       tags: referential


### PR DESCRIPTION
- `functions/local-dependencies`:
  - `serviceBusOptions`:
	- Add the `enabled` property (bool), or remove the parameter
	- Remove the `authorizeClients` property (was not used)
  - `storageAccountsOptions`:
	- Add the `enabled` property (bool), or remove the parameter
	- Remove the `authorizeClients` property (was not used)
	- Remove the `readOnly` property from the object of the `accounts` array
  - `cosmosAccountOptions`:
	- Move in this node the previous `cosmosContainers` parameter, as a `containers` setting
	- Add the `enabled` property (bool), or remove the parameter
  - `functionsAppOptions`:
    - Move in this node the previous `applicationType` parameter, as a `stack` setting
    - Move in this node the previous `extraAppSettings` parameter, as a `extraAppSettings` setting
    - Move in this node the previous `extraIdentities` parameter, as a `extraIdentities` setting
    - Move in this node the previous `deploymentSlots` parameter, as a `extraSlots` setting
    - Move in this node the previous `openIdConfiguration` parameter, as a `openId` setting

- `functions/template`:
  - `serviceBusOptions`:
	- Add the `enabled` property (bool), or remove the parameter
  - `storageAccountsOptions`:
	- Add the `enabled` property (bool), or remove the parameter
  - `cosmosAccountOptions`:
	- Move in this node the previous `cosmosContainers` parameters, as a `containers` setting
	- Add the `enabled` property (bool), or remove the parameter
  - `staticWebAppOptions`:
    - Move in this node the previous `staticWebApp` parameters


